### PR TITLE
fix unicode error when using "Require these letters…" option

### DIFF
--- a/word-o-mat.roboFontExt/lib/wordomat.py
+++ b/word-o-mat.roboFontExt/lib/wordomat.py
@@ -394,7 +394,7 @@ class WordomatWindow:
                         message ("word-o-mat: Sorry, matching by glyph name is only supported when a font is open. Character \"%s\" will be skipped." % c)
             else: # character values
                 result2.append(c)
-        result = [unicode(s) for s in result2 if s]
+        result = [s for s in result2 if s]
         return result
 
 


### PR DESCRIPTION
Hi Nina,

I was getting an error in RF3 when I used the "Require these letters…" option. I removed the unicode() around s and now this option is working in RF3. Hope this is helpful! 

–CJ